### PR TITLE
Add guiding principles for archival access

### DIFF
--- a/archival-access-values.md
+++ b/archival-access-values.md
@@ -1,0 +1,19 @@
+# Guiding Principles for Archival Access
+
+## Open by default
+Start with open access to archival records and description, support the application of consistent, documented, and transparent restrictions.
+
+## Self-directed
+Users should be able to adjust the level of mediation necessary for them to use archival records. Interfaces should allow users to self-serve if desired but also ask for expert help when it is needed.
+
+## Respect privacy
+Minimize the amount and sensitivity of user data collected (including by and via third parties), and apply sensible data retention policies.
+
+## Generative
+Support multiple pathways into and through description and records including people, organizations and subjects. Support multiple modes of inquiry including machines, humans and machine-assisted humans. Encourage and reward curiosity.
+
+## Responsive and accessible
+Adapt to users’ needs and their devices.
+
+## Enhance archival processes
+Enable reference staff to focus on identifiable core activities. Provide infrastructure to support other RAC initiatives.


### PR DESCRIPTION
The Guiding Principles for Archival Access were on the Project Electron website, but as part of decommissioning that site, we decided to move them to this repository. 